### PR TITLE
controller dispose called before super

### DIFF
--- a/lib/showcase.dart
+++ b/lib/showcase.dart
@@ -126,8 +126,8 @@ class _ShowcaseState extends State<Showcase> with TickerProviderStateMixin {
 
   @override
   void dispose() {
-    super.dispose();
     _slideAnimationController.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
#6 Issue resolved

_`slideAnimationController.dispose();` called before `super.dispose()`